### PR TITLE
Change scope for Github permissions

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -6,7 +6,7 @@
   </head>
   <body>
     <p>Well, hello there!</p>
-    <p>We're going to now talk to the GitHub API. Ready? <a href="https://github.com/login/oauth/authorize?scope=user:email&client_id=<%= client_id %>">Click here</a> to begin!</a></p>
+    <p>We're going to now talk to the GitHub API. Ready? <a href="https://github.com/login/oauth/authorize?scope=public_repo&client_id=<%= client_id %>">Click here</a> to begin!</a></p>
     <p>If that link doesn't work, remember to provide your own <a href="http://developer.github.com/v3/oauth/#web-application-flow">Client ID</a>!</p>
   </body>
 </html>


### PR DESCRIPTION
In order to edit content inside the alpha site repository, we need read/write
access to public repositories.
